### PR TITLE
Fix compile errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 FetchContent_Declare(ftxui
   GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-  GIT_TAG v4.0.0
+  GIT_TAG v4.1.1
 )
 
 FetchContent_GetProperties(ftxui)

--- a/src/Algo.cpp
+++ b/src/Algo.cpp
@@ -1,5 +1,11 @@
 #include "Algo.h"
 
+#include <algorithm>
+#include <random>
+
+std::random_device random_source;
+std::mt19937 random_generator(random_source());
+
 // distance of the path
 int distance_path = 0;
 
@@ -439,7 +445,7 @@ get_neighbors(Matrix& mat, point t_point){
 		}
 	}
 
-	std::random_shuffle(neigh.begin(), neigh.end());
+	std::shuffle(neigh.begin(), neigh.end(), random_generator);
 
 	return neigh; 
 }


### PR DESCRIPTION
- FTXUI v4.0.0 was not properly propagating c++17 requirements to dependencies. Increasing to v4.1.1 fixes the issue.

- std::random_shuffle is removed in C++17. Use `std::shuffle` instead.